### PR TITLE
Call bash through `env`.

### DIFF
--- a/bin/symlink_public
+++ b/bin/symlink_public
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -rf public
 mkdir public


### PR DESCRIPTION
My Linux distribution does not have /usr/bin/bash nor /bin/bash.