### PR TITLE
Moved minimist from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,8 @@
     "mime": "^1.2.11",
     "moment": "^2.8.3",
     "morgan": "^1.3.1",
-    "xml2js": "^0.4.4"
-  },
-  "devDependencies": {
+    "xml2js": "^0.4.4",
     "minimist": "^1.1.0"
-  }
+  },
+  "devDependencies": {}
 }


### PR DESCRIPTION
Minimist is used by the xunit-viewer script so it breaks when users
install xunit-reports-viewer with:

```
npm install -g xunit-reports-viewer
```

This is because `npm install` does not install devDependencies.
